### PR TITLE
Add support for OpenAPI 3 schema change in Netbox 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.4.1] (2025-01-23)
+
+* Backport [fix](https://github.com/fbreckle/go-netbox/pull/41) from e-breuninger/terraform-provider-netbox for OpenAPI 3 schema changes in Netbox v4.x 
+
+
+### Features
+
+* Update from Netbox 3.4 swagger ([ec98310](https://github.com/smutel/go-netbox/commit/ec98310e2ebcaaf3b43ac6c7f14de8ea112b37e6))
+
 ## [3.4.0](https://github.com/smutel/go-netbox/compare/v3.3.0...v3.4.0) (2023-06-12)
 
 

--- a/netbox/models/nested_ip_address.go
+++ b/netbox/models/nested_ip_address.go
@@ -46,7 +46,7 @@ type NestedIPAddress struct {
 
 	// Family
 	// Read Only: true
-	Family int64 `json:"family,omitempty"`
+	Family interface{} `json:"family,omitempty"`
 
 	// ID
 	// Read Only: true
@@ -105,10 +105,6 @@ func (m *NestedIPAddress) ContextValidate(ctx context.Context, formats strfmt.Re
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateFamily(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateID(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -126,15 +122,6 @@ func (m *NestedIPAddress) ContextValidate(ctx context.Context, formats strfmt.Re
 func (m *NestedIPAddress) contextValidateDisplay(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "display", "body", string(m.Display)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *NestedIPAddress) contextValidateFamily(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "family", "body", int64(m.Family)); err != nil {
 		return err
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "go-netbox",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Go library to interact with NetBox IPAM and DCIM service"
 }


### PR DESCRIPTION
## What does this change resolves ?
- it backports [fix](https://github.com/fbreckle/go-netbox/pull/41) from `fbreckle/go-netbox` to enable support for Netbox 4.x:
- fixes the following error in go-netbox REST API call to [dcim_devices_retrieve](https://demo.netbox.dev/api/schema/swagger-ui/#/dcim/dcim_devices_retrieve) resource in Netbox
- tested with Netbox `v4.1.11` version

> Error: json: cannot unmarshal object into Go struct field NestedIPAddress.results.primary_ip.family of type int64

 